### PR TITLE
Refatora pipeline em módulos

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,35 @@
+-- Script manual para recriar as tabelas utilizadas pelo DETRAF
+-- Não executado automaticamente; use conforme necessário.
+
+DROP TABLE IF EXISTS detraf_conferencia;
+DROP TABLE IF EXISTS detraf;
+
+CREATE TABLE detraf (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    eot VARCHAR(10) NOT NULL,
+    sequencial BIGINT,
+    assinante_a_numero VARCHAR(32),
+    eot_de_a VARCHAR(10),
+    cnl_de_a VARCHAR(10),
+    area_local_de_a VARCHAR(10),
+    data_da_chamada CHAR(8),
+    hora_de_atendimento CHAR(6),
+    assinante_b_numero VARCHAR(32),
+    eot_de_b VARCHAR(10),
+    cnl_de_b VARCHAR(10),
+    area_local_de_b VARCHAR(10),
+    data_hora DATETIME,
+    INDEX idx_detraf_data_hora (data_hora)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE detraf_conferencia (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    detraf_id BIGINT NOT NULL,
+    cdr_id BIGINT NULL,
+    status VARCHAR(20) NOT NULL,
+    observacao VARCHAR(255) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_detraf_id (detraf_id),
+    INDEX idx_cdr_id (cdr_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+

--- a/src/detraf/__init__.py
+++ b/src/detraf/__init__.py
@@ -1,2 +1,15 @@
-__all__ = ["__version__"]
+"""Pacote principal do analisador DETRAF."""
+
+from . import import_detraf, match_cdr, normalizer, processing, main, schema
+
+__all__ = [
+    "__version__",
+    "import_detraf",
+    "match_cdr",
+    "normalizer",
+    "processing",
+    "main",
+    "schema",
+]
+
 __version__ = "2.0.0"

--- a/src/detraf/cli.py
+++ b/src/detraf/cli.py
@@ -223,7 +223,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     try:
         from .processing import processar_match  # type: ignore
         ok("Importação concluída. Prosseguindo com matching e classificação...")
-        processar_match(periodo)
+        processar_match()
         ok("Processamento completo: detraf_conferencia preenchida.")
     except Exception:
         # Se o projeto não tiver essas rotinas, apenas finalizar.

--- a/src/detraf/db.py
+++ b/src/detraf/db.py
@@ -1,6 +1,5 @@
 
 from __future__ import annotations
-from typing import Optional
 import pymysql
 from .env import load_env
 from .log import ok, err
@@ -10,19 +9,32 @@ def is_db_configured() -> bool:
     req = ["DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME"]
     return all(env.get(k) for k in req)
 
-def get_conn():
-    """Connection factory expected by import_detraf_fw (name: get_conn)."""
+def get_conn_params() -> dict:
+    """Retorna kwargs padrão para ``pymysql.connect``.
+
+    Usado por módulos que precisam de uma conexão explícita ou para
+    obter os parâmetros e ajustar ``autocommit`` ou outras opções.
+    """
     env = load_env()
-    conn = pymysql.connect(
-        host=env.get("DB_HOST", "localhost"),
-        port=int(env.get("DB_PORT", "3306")),
-        user=env.get("DB_USER", ""),
-        password=env.get("DB_PASSWORD", ""),
-        database=env.get("DB_NAME", ""),
-        autocommit=True,
-        cursorclass=pymysql.cursors.DictCursor,
-    )
-    return conn
+    return {
+        "host": env.get("DB_HOST", "localhost"),
+        "port": int(env.get("DB_PORT", "3306")),
+        "user": env.get("DB_USER", ""),
+        "password": env.get("DB_PASSWORD", ""),
+        "database": env.get("DB_NAME", ""),
+        "autocommit": True,
+        "cursorclass": pymysql.cursors.DictCursor,
+    }
+
+
+def get_connection():
+    """Conveniência para ``pymysql.connect`` usando ``get_conn_params``."""
+    return pymysql.connect(**get_conn_params())
+
+
+def get_conn():
+    """Factory compatível com ``import_detraf_fw`` (nome legado)."""
+    return get_connection()
 
 def test_connection() -> bool:
     try:

--- a/src/detraf/import_detraf_fw.py
+++ b/src/detraf/import_detraf_fw.py
@@ -121,22 +121,14 @@ def _progress(curr: int, total: int, started_at: float, every: int = 1000) -> No
 # ----------------------------------------------------------------------
 _SQL_INSERT = """
 INSERT INTO detraf (
-    eot, sequencial, assinante_a, eot_de_a, cnl_de_a, area_local_de_a,
+    eot, sequencial, assinante_a_numero, eot_de_a, cnl_de_a, area_local_de_a,
     data_da_chamada, hora_de_atendimento,
-    assinante_b, eot_de_b, cnl_de_b, area_local_de_b,
-    classe, categoria, condicao_b, grupo_horario, povpi, a_num, b_num,
-    valor_bruto, descontos_e_encargos, valor_liquido,
-    eqt_receita, eqt_despesa, eqt_filial_receita, eqt_filial_despesa,
-    descritor_de_cdr,
+    assinante_b_numero, eot_de_b, cnl_de_b, area_local_de_b,
     data_hora
 ) VALUES (
     %s, %s, %s, %s, %s, %s,
     %s, %s,
     %s, %s, %s, %s,
-    %s, %s, %s, %s, %s, %s, %s,
-    %s, %s, %s,
-    %s, %s, %s, %s,
-    %s,
     STR_TO_DATE(CONCAT(%s, ' ', %s), '%%Y%%m%%d %%H%%i%%s')
 )
 """
@@ -183,34 +175,16 @@ def importar_fixowidth_para_detraf(caminho: str, layout_path: str, periodo: str 
             except Exception:
                 sequencial = None
 
-            assinante_a = _clean(rec.get("assinante_a", ""))
+            assinante_a_numero = _clean(rec.get("assinante_a", ""))
             eot_de_a = _clean(rec.get("eot_de_a", ""))
             cnl_de_a = _clean(rec.get("cnl_de_a", ""))
             area_local_de_a = _clean(rec.get("area_local_de_a", ""))
             data_da_chamada = _clean(rec.get("data_da_chamada", ""))
             hora_de_atendimento = _clean(rec.get("hora_de_atendimento", ""))
-            assinante_b = _clean(rec.get("assinante_b", ""))
+            assinante_b_numero = _clean(rec.get("assinante_b", ""))
             eot_de_b = _clean(rec.get("eot_de_b", ""))
             cnl_de_b = _clean(rec.get("cnl_de_b", ""))
             area_local_de_b = _clean(rec.get("area_local_de_b", ""))
-
-            classe = _clean(rec.get("classe", ""))
-            categoria = _clean(rec.get("categoria", ""))
-            condicao_b = _clean(rec.get("condicao_b", ""))
-            grupo_horario = _clean(rec.get("grupo_horario", ""))
-            povpi = _clean(rec.get("povpi", ""))
-            a_num = _clean(rec.get("a_num", ""))
-            b_num = _clean(rec.get("b_num", ""))
-
-            valor_bruto = _clean_num(rec.get("valor_bruto", ""))
-            descontos_e_encargos = _clean_num(rec.get("descontos_e_encargos", ""))
-            valor_liquido = _clean_num(rec.get("valor_liquido", ""))
-
-            eqt_receita = _clean(rec.get("eqt_receita", ""))
-            eqt_despesa = _clean(rec.get("eqt_despesa", ""))
-            eqt_filial_receita = _clean(rec.get("eqt_filial_receita", ""))
-            eqt_filial_despesa = _clean(rec.get("eqt_filial_despesa", ""))
-            descritor_de_cdr = _clean(rec.get("descritor_de_cdr", ""))
 
             # Filtro por periodo YYYYMM (data da chamada)
             if periodo:
@@ -226,13 +200,9 @@ def importar_fixowidth_para_detraf(caminho: str, layout_path: str, periodo: str 
             eot_ctx = (eot or "AUTO").strip() or "AUTO"
 
             row = (
-                eot_ctx, sequencial, assinante_a, eot_de_a, cnl_de_a, area_local_de_a,
+                eot_ctx, sequencial, assinante_a_numero, eot_de_a, cnl_de_a, area_local_de_a,
                 data_da_chamada, hora_de_atendimento,
-                assinante_b, eot_de_b, cnl_de_b, area_local_de_b,
-                classe, categoria, condicao_b, grupo_horario, povpi, a_num, b_num,
-                valor_bruto, descontos_e_encargos, valor_liquido,
-                eqt_receita, eqt_despesa, eqt_filial_receita, eqt_filial_despesa,
-                descritor_de_cdr,
+                assinante_b_numero, eot_de_b, cnl_de_b, area_local_de_b,
                 data_str, hora_str,
             )
             batch.append(row)

--- a/src/detraf/log.py
+++ b/src/detraf/log.py
@@ -9,6 +9,12 @@ def section(title: str) -> None:
     bar = "─" * (len(title) + 2)
     print(f"╭{bar}╮\n│ {title} │\n╰{bar}╯")
 
+# Compatibilidade com versões anteriores
+header = section
+
+def info(msg: str) -> None:
+    print(f"{_ts()} {msg}")
+
 def ok(msg: str) -> None:
     print(f"{_ts()} OK {msg}")
 

--- a/src/detraf/main.py
+++ b/src/detraf/main.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+"""Entrada programática para executar o pipeline DETRAF."""
+
+from .import_detraf import importar_arquivo_txt
+from .match_cdr import processar_match
+from .processing import begin_processing
+
+
+def executar(periodo: str, eot: str, arquivo: str) -> None:
+    """Executa a preparação, importação e o batimento completo.
+
+    Parâmetros
+    ----------
+    periodo: str
+        Mês de referência no formato ``YYYYMM``.
+    eot: str
+        Código EOT a ser aplicado durante a importação.
+    arquivo: str
+        Caminho para o arquivo DETRAF fornecido pela operadora.
+    """
+    begin_processing(periodo, eot, arquivo)
+    importar_arquivo_txt(arquivo, periodo, eot)
+    processar_match()

--- a/src/detraf/normalizer.py
+++ b/src/detraf/normalizer.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+"""Funções de normalização de números para CDR e DETRAF."""
+
+from .log import ok
+
+
+def criar_tmp_detraf(cur, tmp_name: str, min_dt, max_dt) -> None:
+    """Cria tabela temporária do DETRAF com números normalizados.
+
+    Remove caracteres não numéricos e cria versões curtas (8/9 dígitos)
+    para batimento com o CDR. Números iniciados por ``0800`` são
+    preservados integralmente.
+    """
+    cur.execute(
+        f"""
+        CREATE TEMPORARY TABLE {tmp_name} AS
+        SELECT id, data_hora, eot_de_a, eot_de_b,
+               assinante_a_numero AS a_num,
+               assinante_b_numero AS b_num,
+               REGEXP_REPLACE(assinante_a_numero, '[^0-9]', '') AS a_digits,
+               REGEXP_REPLACE(assinante_b_numero, '[^0-9]', '') AS b_digits
+        FROM detraf
+        WHERE data_hora BETWEEN %s AND %s
+        """,
+        (min_dt, max_dt),
+    )
+    cur.execute(
+        f"""
+        ALTER TABLE {tmp_name}
+        ADD COLUMN a_short VARCHAR(32),
+        ADD COLUMN b_short VARCHAR(32)
+        """,
+    )
+    cur.execute(
+        f"""
+        UPDATE {tmp_name}
+        SET a_short = CASE
+                        WHEN a_digits LIKE '0800%' THEN a_digits
+                        WHEN CHAR_LENGTH(a_digits)=10 THEN RIGHT(a_digits,8)
+                        WHEN CHAR_LENGTH(a_digits)=11 THEN RIGHT(a_digits,9)
+                        ELSE a_digits
+                      END,
+            b_short = CASE
+                        WHEN b_digits LIKE '0800%' THEN b_digits
+                        WHEN CHAR_LENGTH(b_digits)=10 THEN RIGHT(b_digits,8)
+                        WHEN CHAR_LENGTH(b_digits)=11 THEN RIGHT(b_digits,9)
+                        ELSE b_digits
+                      END
+        """,
+    )
+    ok(f"Tabela temporária criada: {tmp_name}")
+
+
+def criar_tmp_cdr(cur, tmp_name: str, min_dt, max_dt) -> None:
+    """Cria tabela temporária do CDR com números normalizados."""
+    cur.execute(
+        f"""
+        CREATE TEMPORARY TABLE {tmp_name} AS
+        SELECT id, calldate, src, dst, EOT_A, EOT_B,
+               REGEXP_REPLACE(src, '[^0-9]', '') AS src_digits,
+               REGEXP_REPLACE(dst, '[^0-9]', '') AS dst_digits
+        FROM cdr
+        WHERE calldate BETWEEN %s AND %s
+        """,
+        (min_dt, max_dt),
+    )
+    cur.execute(
+        f"""
+        ALTER TABLE {tmp_name}
+        ADD COLUMN src_short VARCHAR(32),
+        ADD COLUMN dst_short VARCHAR(32)
+        """,
+    )
+    cur.execute(
+        f"""
+        UPDATE {tmp_name}
+        SET src_short = CASE
+                          WHEN CHAR_LENGTH(src_digits)=10 THEN RIGHT(src_digits,8)
+                          WHEN CHAR_LENGTH(src_digits)=11 THEN RIGHT(src_digits,9)
+                          ELSE src_digits
+                        END,
+            dst_short = CASE
+                          WHEN CHAR_LENGTH(dst_digits)=10 THEN RIGHT(dst_digits,8)
+                          WHEN CHAR_LENGTH(dst_digits)=11 THEN RIGHT(dst_digits,9)
+                          ELSE dst_digits
+                        END
+        """,
+    )
+    ok(f"Tabela temporária criada: {tmp_name}")

--- a/src/detraf/processing.py
+++ b/src/detraf/processing.py
@@ -135,12 +135,13 @@ def begin_processing(periodo: str, eot: str, arquivo: str) -> Tuple[str, str]:
     return dt_ini.strftime("%Y-%m-%d %H:%M:%S"), dt_fim.strftime("%Y-%m-%d %H:%M:%S")
 
 # === Pipeline: comparação/matching (mínimo seguro) ===
-def processar_match(periodo: str) -> None:
-    """
+def processar_match() -> None:
+    """Matching simplificado para uso após a importação.
+
     Implementação mínima e segura:
-      - Se detraf não existir ou estiver vazia, avisa e retorna.
-      - Não cria/edita schema. Não escreve em detraf_conferencia para evitar conflito.
-    Seu importador/rotina específica pode substituir esta função depois.
+      - Se ``detraf`` não existir ou estiver vazia, apenas avisa.
+      - Não altera schema nem grava em ``detraf_conferencia``.
+    Pode ser substituída por uma rotina mais completa conforme a necessidade.
     """
     try:
         conn = get_connection()

--- a/src/detraf/schema.py
+++ b/src/detraf/schema.py
@@ -1,0 +1,62 @@
+"""Utilitário para recriar tabelas necessárias ao DETRAF.
+
+Uso:
+    python -m detraf.schema
+
+O script elimina e recria as tabelas ``detraf`` e ``detraf_conferencia``
+com campos compatíveis com o pipeline de importação e batimento.
+"""
+
+from __future__ import annotations
+import pymysql
+from .db import get_connection
+from .log import info, ok
+
+CREATE_DETRAF = """
+CREATE TABLE detraf (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    eot VARCHAR(10) NOT NULL,
+    sequencial BIGINT,
+    assinante_a_numero VARCHAR(32),
+    eot_de_a VARCHAR(10),
+    cnl_de_a VARCHAR(10),
+    area_local_de_a VARCHAR(10),
+    data_da_chamada CHAR(8),
+    hora_de_atendimento CHAR(6),
+    assinante_b_numero VARCHAR(32),
+    eot_de_b VARCHAR(10),
+    cnl_de_b VARCHAR(10),
+    area_local_de_b VARCHAR(10),
+    data_hora DATETIME,
+    INDEX idx_detraf_data_hora (data_hora)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+"""
+
+CREATE_CONFERENCIA = """
+CREATE TABLE detraf_conferencia (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    detraf_id BIGINT NOT NULL,
+    cdr_id BIGINT NULL,
+    status VARCHAR(20) NOT NULL,
+    observacao VARCHAR(255) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_detraf_id (detraf_id),
+    INDEX idx_cdr_id (cdr_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+"""
+
+def reset_schema() -> None:
+    """Dropa e recria as tabelas ``detraf`` e ``detraf_conferencia``."""
+    with get_connection() as conn:  # autocommit=True no get_connection
+        cur = conn.cursor()
+        info("Removendo tabelas antigas se existirem...")
+        cur.execute("DROP TABLE IF EXISTS detraf_conferencia")
+        cur.execute("DROP TABLE IF EXISTS detraf")
+        info("Criando tabela detraf...")
+        cur.execute(CREATE_DETRAF)
+        info("Criando tabela detraf_conferencia...")
+        cur.execute(CREATE_CONFERENCIA)
+        ok("Tabelas detraf e detraf_conferencia recriadas.")
+
+if __name__ == "__main__":
+    reset_schema()


### PR DESCRIPTION
## Resumo
- Adiciona módulo `normalizer` para normalização de números de CDR e DETRAF
- Atualiza `match_cdr` para reutilizar o normalizador e facilitar o batimento
- Inclui `main.executar` como ponto de entrada programático do pipeline
- Ajusta utilitário de log com funções `info` e `header`
- Exponde helpers `get_conn_params`/`get_connection` e usa conexão consistente
- Sanitiza números do DETRAF preservando prefixo 0800 e gera colunas curtas
- Remove parâmetro `periodo` não usado em `processar_match`
- Simplifica inserção do DETRAF para refletir colunas realmente existentes
- Acrescenta `schema.py` para recriação manual das tabelas `detraf` e `detraf_conferencia`
- Adiciona script SQL para recriar manualmente as tabelas do DETRAF

## Testes
- `python -m py_compile src/detraf/db.py src/detraf/normalizer.py src/detraf/match_cdr.py src/detraf/main.py src/detraf/processing.py src/detraf/cli.py src/detraf/import_detraf_fw.py src/detraf/import_detraf.py src/detraf/__init__.py src/detraf/schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68bed5eabd908333809b0bfcdaaac044