### PR TITLE
Implement detailed CDR normalization rules

### DIFF
--- a/src/detraf/normalizer.py
+++ b/src/detraf/normalizer.py
@@ -1,7 +1,86 @@
 from __future__ import annotations
-"""Funções de normalização de números para CDR e DETRAF."""
+"""Funções de normalização de números para CDR e DETRAF.
+
+Este módulo continha apenas uma limpeza simples dos números do CDR. As
+novas regras de negócio exigem uma normalização mais rigorosa para que o
+batimento com o DETRAF seja confiável. O CDR possui numerações em formatos
+diversos (com DDI/DDD, prefixos, etc.) e, em alguns casos, números locais
+sem DDD. Também é necessário tratar chamadas para 0800 que possuem
+tarifação reversa.
+
+Para facilitar o entendimento e reutilização, a normalização é feita em
+Python e os números inválidos são descartados. A tabela temporária gerada
+contém os campos relevantes do CDR já normalizados e versões "curtas" para
+batimento com o DETRAF.
+"""
+
+from typing import Optional
+import re
 
 from .log import ok
+
+
+def _digits(valor: Optional[str]) -> str:
+    """Remove caracteres não numéricos de ``valor``."""
+    if not valor:
+        return ""
+    return re.sub(r"[^0-9]", "", valor)
+
+
+def _short(numero: str) -> str:
+    """Versão curta usada no batimento com o DETRAF.
+
+    - 0800: mantém o valor integral (10 dígitos começando por ``800``)
+    - 10 dígitos: últimos 8
+    - 11 dígitos: últimos 9
+    - outros: número integral
+    """
+    if numero.startswith("800") and len(numero) == 10:
+        return numero
+    if len(numero) == 10:
+        return numero[-8:]
+    if len(numero) == 11:
+        return numero[-9:]
+    return numero
+
+
+def _normalizar_numero(numero: str, ddd_ref: Optional[str] = None, *, is_dst: bool = False) -> Optional[str]:
+    """Normaliza ``numero`` segundo as regras de negócio.
+
+    ``ddd_ref`` é usado para completar números locais (sem DDD) do ``dst``
+    utilizando o DDD do ``src``. Quando ``is_dst`` é ``True`` são aplicadas
+    as regras de identificação de chamadas para 0800.
+    """
+
+    digitos = _digits(numero)
+    if not digitos:
+        return None
+
+    # Remove DDI 55 quando presente
+    if digitos.startswith("55") and len(digitos) > 11:
+        digitos = digitos[2:]
+
+    # Tratamento específico para 0800 no destino (tarifação reversa)
+    if is_dst and len(digitos) >= 11 and digitos[6:10] == "0800":
+        digitos = digitos[-10:]
+        if digitos.startswith("0"):
+            digitos = digitos[1:]
+        return digitos if len(digitos) == 10 else None
+
+    # Casos comuns
+    if len(digitos) == 9 and digitos[0] == "9":
+        return (ddd_ref or "") + digitos if ddd_ref else None
+
+    if len(digitos) == 8 and digitos[0] in "2345":
+        return (ddd_ref or "") + digitos if ddd_ref else None
+
+    if len(digitos) >= 11 and digitos[2] == "9":
+        return digitos[:11]
+
+    if len(digitos) >= 10 and digitos[2] in "2345":
+        return digitos[-10:]
+
+    return None
 
 
 def criar_tmp_detraf(cur, tmp_name: str, min_dt, max_dt) -> None:
@@ -52,38 +131,84 @@ def criar_tmp_detraf(cur, tmp_name: str, min_dt, max_dt) -> None:
 
 
 def criar_tmp_cdr(cur, tmp_name: str, min_dt, max_dt) -> None:
-    """Cria tabela temporária do CDR com números normalizados."""
+    """Cria tabela temporária do CDR com números normalizados.
+
+    A normalização é realizada em Python devido à quantidade de regras de
+    negócio envolvidas. Apenas os registros com ``src`` e ``dst`` válidos
+    são inseridos na tabela temporária.
+    """
+
+    # Estrutura básica da tabela temporária
     cur.execute(
         f"""
-        CREATE TEMPORARY TABLE {tmp_name} AS
+        CREATE TEMPORARY TABLE {tmp_name} (
+            id BIGINT,
+            calldate DATETIME,
+            src VARCHAR(32),
+            dst VARCHAR(32),
+            EOT_A VARCHAR(32),
+            EOT_B VARCHAR(32),
+            duration INT,
+            billsec INT,
+            sentido VARCHAR(16),
+            disposition VARCHAR(32),
+            src_short VARCHAR(32),
+            dst_short VARCHAR(32)
+        )
+        """
+    )
+
+    # Coleta dos registros dentro da janela desejada
+    cur.execute(
+        """
         SELECT id, calldate, src, dst, EOT_A, EOT_B,
-               REGEXP_REPLACE(src, '[^0-9]', '') AS src_digits,
-               REGEXP_REPLACE(dst, '[^0-9]', '') AS dst_digits
+               duration, billsec, sentido, disposition
         FROM cdr
         WHERE calldate BETWEEN %s AND %s
         """,
         (min_dt, max_dt),
     )
-    cur.execute(
-        f"""
-        ALTER TABLE {tmp_name}
-        ADD COLUMN src_short VARCHAR(32),
-        ADD COLUMN dst_short VARCHAR(32)
-        """,
-    )
-    cur.execute(
-        f"""
-        UPDATE {tmp_name}
-        SET src_short = CASE
-                          WHEN CHAR_LENGTH(src_digits)=10 THEN RIGHT(src_digits,8)
-                          WHEN CHAR_LENGTH(src_digits)=11 THEN RIGHT(src_digits,9)
-                          ELSE src_digits
-                        END,
-            dst_short = CASE
-                          WHEN CHAR_LENGTH(dst_digits)=10 THEN RIGHT(dst_digits,8)
-                          WHEN CHAR_LENGTH(dst_digits)=11 THEN RIGHT(dst_digits,9)
-                          ELSE dst_digits
-                        END
-        """,
-    )
+
+    rows = cur.fetchall()
+    ins_rows = []
+    for row in rows:
+        src_norm = _normalizar_numero(row["src"])
+        if not src_norm:
+            continue
+        ddd_src = src_norm[:2]
+
+        dst_norm = _normalizar_numero(row["dst"], ddd_ref=ddd_src, is_dst=True)
+        if not dst_norm:
+            continue
+
+        ins_rows.append(
+            (
+                row["id"],
+                row["calldate"],
+                src_norm,
+                dst_norm,
+                row["EOT_A"],
+                row["EOT_B"],
+                row["duration"],
+                row["billsec"],
+                row["sentido"],
+                row["disposition"],
+                _short(src_norm),
+                _short(dst_norm),
+            )
+        )
+
+    if ins_rows:
+        cur.executemany(
+            f"""
+            INSERT INTO {tmp_name}
+                (id, calldate, src, dst, EOT_A, EOT_B,
+                 duration, billsec, sentido, disposition,
+                 src_short, dst_short)
+            VALUES
+                (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            """,
+            ins_rows,
+        )
+
     ok(f"Tabela temporária criada: {tmp_name}")


### PR DESCRIPTION
## Summary
- Replace simplistic CDR cleanup with full business-rule normalization
- Handle 0800 reverse-charge numbers and local mobile/fixed cases
- Create temporary CDR table with normalized numbers and short forms

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c06263e248833386cf4374615f4243