### PR TITLE
Persist normalized CDR data without short fields

### DIFF
--- a/src/detraf/match_cdr.py
+++ b/src/detraf/match_cdr.py
@@ -3,7 +3,7 @@ import time
 import pymysql
 from .db import get_conn_params
 from .env import load_env
-from .log import info, ok, warn, err
+from .log import info, ok, warn
 from .normalizer import criar_tmp_cdr, criar_tmp_detraf
 
 def _run_id() -> str:
@@ -14,7 +14,7 @@ def processar_match() -> None:
     load_env()
     params = get_conn_params()
     runid = _run_id()
-    tmp_cdr = f"tmp_cdr_{runid}"
+    tmp_cdr = "cdr_normalizado"
     tmp_detraf = f"tmp_detraf_{runid}"
     tmp_conf = f"tmp_conf_{runid}"
 
@@ -30,7 +30,7 @@ def processar_match() -> None:
             return
         info(f"Janela DETRAF detectada: {min_dt} → {max_dt} | {total_detraf} linhas")
 
-        # tmp_detraf e tmp_cdr com números normalizados
+        # tmp_detraf e cdr normalizado
         criar_tmp_detraf(cur, tmp_detraf, min_dt, max_dt)
         criar_tmp_cdr(cur, tmp_cdr, min_dt, max_dt)
 
@@ -43,8 +43,8 @@ def processar_match() -> None:
                    d.eot_de_a, d.eot_de_b, c.EOT_A, c.EOT_B
             FROM {tmp_detraf} d
             JOIN {tmp_cdr} c
-              ON d.a_short = c.src_short
-             AND d.b_short = c.dst_short
+              ON d.a_num = c.src
+             AND d.b_num = c.dst
              AND ABS(TIMESTAMPDIFF(MINUTE, d.data_hora, c.calldate)) <= 5
         ),
         ranqueados AS (
@@ -86,8 +86,7 @@ def processar_match() -> None:
 
         conn.commit()
 
-        # Drop temporárias
+        # Drop temporárias auxiliares
         cur.execute(f"DROP TEMPORARY TABLE IF EXISTS {tmp_conf}")
-        cur.execute(f"DROP TEMPORARY TABLE IF EXISTS {tmp_cdr}")
         cur.execute(f"DROP TEMPORARY TABLE IF EXISTS {tmp_detraf}")
         ok("Temporárias descartadas.")

--- a/src/detraf/normalizer.py
+++ b/src/detraf/normalizer.py
@@ -1,89 +1,165 @@
 from __future__ import annotations
-"""Funções de normalização de números para CDR e DETRAF."""
+"""Funções de normalização de números para CDR e DETRAF.
+
+Este módulo continha apenas uma limpeza simples dos números do CDR. As
+novas regras de negócio exigem uma normalização mais rigorosa para que o
+batimento com o DETRAF seja confiável. O CDR possui numerações em formatos
+diversos (com DDI/DDD, prefixos, etc.) e, em alguns casos, números locais
+sem DDD. Também é necessário tratar chamadas para 0800 que possuem
+tarifação reversa.
+
+Para facilitar o entendimento e reutilização, a normalização é feita em
+Python e os números inválidos são descartados. A tabela gerada contém os
+campos relevantes do CDR já normalizados.
+"""
+
+from typing import Optional
+import re
 
 from .log import ok
+
+
+def _digits(valor: Optional[str]) -> str:
+    """Remove caracteres não numéricos de ``valor``."""
+    if not valor:
+        return ""
+    return re.sub(r"[^0-9]", "", valor)
+
+
+def _normalizar_numero(numero: str, ddd_ref: Optional[str] = None, *, is_dst: bool = False) -> Optional[str]:
+    """Normaliza ``numero`` segundo as regras de negócio.
+
+    ``ddd_ref`` é usado para completar números locais (sem DDD) do ``dst``
+    utilizando o DDD do ``src``. Quando ``is_dst`` é ``True`` são aplicadas
+    as regras de identificação de chamadas para 0800.
+    """
+
+    digitos = _digits(numero)
+    if not digitos:
+        return None
+
+    # Remove DDI 55 quando presente
+    if digitos.startswith("55") and len(digitos) > 11:
+        digitos = digitos[2:]
+
+    # Tratamento específico para 0800 no destino (tarifação reversa)
+    if is_dst and len(digitos) >= 10:
+        sufixo = digitos[-10:]
+        if sufixo.startswith("0800"):
+            return "800" + sufixo[4:]
+        if sufixo.startswith("800"):
+            return sufixo
+
+    # Casos comuns
+    if len(digitos) == 9 and digitos[0] == "9":
+        return (ddd_ref or "") + digitos if ddd_ref else None
+
+    if len(digitos) == 8 and digitos[0] in "2345":
+        return (ddd_ref or "") + digitos if ddd_ref else None
+
+    if len(digitos) >= 11 and digitos[2] == "9":
+        return digitos[:11]
+
+    if len(digitos) >= 10 and digitos[2] in "2345":
+        return digitos[-10:]
+
+    return None
 
 
 def criar_tmp_detraf(cur, tmp_name: str, min_dt, max_dt) -> None:
     """Cria tabela temporária do DETRAF com números normalizados.
 
-    Remove caracteres não numéricos e cria versões curtas (8/9 dígitos)
-    para batimento com o CDR. Números iniciados por ``0800`` são
-    preservados integralmente.
+    Remove caracteres não numéricos de ``assinante_a_numero`` e
+    ``assinante_b_numero`` para facilitar o batimento com o CDR.
     """
     cur.execute(
         f"""
         CREATE TEMPORARY TABLE {tmp_name} AS
         SELECT id, data_hora, eot_de_a, eot_de_b,
-               assinante_a_numero AS a_num,
-               assinante_b_numero AS b_num,
-               REGEXP_REPLACE(assinante_a_numero, '[^0-9]', '') AS a_digits,
-               REGEXP_REPLACE(assinante_b_numero, '[^0-9]', '') AS b_digits
+               REGEXP_REPLACE(assinante_a_numero, '[^0-9]', '') AS a_num,
+               REGEXP_REPLACE(assinante_b_numero, '[^0-9]', '') AS b_num
         FROM detraf
         WHERE data_hora BETWEEN %s AND %s
         """,
         (min_dt, max_dt),
     )
-    cur.execute(
-        f"""
-        ALTER TABLE {tmp_name}
-        ADD COLUMN a_short VARCHAR(32),
-        ADD COLUMN b_short VARCHAR(32)
-        """,
-    )
-    cur.execute(
-        f"""
-        UPDATE {tmp_name}
-        SET a_short = CASE
-                        WHEN a_digits LIKE '0800%' THEN a_digits
-                        WHEN CHAR_LENGTH(a_digits)=10 THEN RIGHT(a_digits,8)
-                        WHEN CHAR_LENGTH(a_digits)=11 THEN RIGHT(a_digits,9)
-                        ELSE a_digits
-                      END,
-            b_short = CASE
-                        WHEN b_digits LIKE '0800%' THEN b_digits
-                        WHEN CHAR_LENGTH(b_digits)=10 THEN RIGHT(b_digits,8)
-                        WHEN CHAR_LENGTH(b_digits)=11 THEN RIGHT(b_digits,9)
-                        ELSE b_digits
-                      END
-        """,
-    )
     ok(f"Tabela temporária criada: {tmp_name}")
 
 
 def criar_tmp_cdr(cur, tmp_name: str, min_dt, max_dt) -> None:
-    """Cria tabela temporária do CDR com números normalizados."""
+    """Cria tabela do CDR com números normalizados.
+
+    A tabela é recriada a cada execução, mantendo os registros normalizados
+    para inspeção posterior.
+    """
+
+    # Recria tabela persistente
+    cur.execute(f"DROP TABLE IF EXISTS {tmp_name}")
     cur.execute(
         f"""
-        CREATE TEMPORARY TABLE {tmp_name} AS
+        CREATE TABLE {tmp_name} (
+            id BIGINT,
+            calldate DATETIME,
+            src VARCHAR(32),
+            dst VARCHAR(32),
+            EOT_A VARCHAR(32),
+            EOT_B VARCHAR(32),
+            duration INT,
+            billsec INT,
+            sentido VARCHAR(16),
+            disposition VARCHAR(32)
+        )
+        """
+    )
+
+    # Coleta dos registros dentro da janela desejada
+    cur.execute(
+        """
         SELECT id, calldate, src, dst, EOT_A, EOT_B,
-               REGEXP_REPLACE(src, '[^0-9]', '') AS src_digits,
-               REGEXP_REPLACE(dst, '[^0-9]', '') AS dst_digits
+               duration, billsec, sentido, disposition
         FROM cdr
         WHERE calldate BETWEEN %s AND %s
         """,
         (min_dt, max_dt),
     )
-    cur.execute(
-        f"""
-        ALTER TABLE {tmp_name}
-        ADD COLUMN src_short VARCHAR(32),
-        ADD COLUMN dst_short VARCHAR(32)
-        """,
-    )
-    cur.execute(
-        f"""
-        UPDATE {tmp_name}
-        SET src_short = CASE
-                          WHEN CHAR_LENGTH(src_digits)=10 THEN RIGHT(src_digits,8)
-                          WHEN CHAR_LENGTH(src_digits)=11 THEN RIGHT(src_digits,9)
-                          ELSE src_digits
-                        END,
-            dst_short = CASE
-                          WHEN CHAR_LENGTH(dst_digits)=10 THEN RIGHT(dst_digits,8)
-                          WHEN CHAR_LENGTH(dst_digits)=11 THEN RIGHT(dst_digits,9)
-                          ELSE dst_digits
-                        END
-        """,
-    )
-    ok(f"Tabela temporária criada: {tmp_name}")
+
+    rows = cur.fetchall()
+    ins_rows = []
+    for row in rows:
+        src_norm = _normalizar_numero(row["src"])
+        if not src_norm:
+            continue
+        ddd_src = src_norm[:2]
+
+        dst_norm = _normalizar_numero(row["dst"], ddd_ref=ddd_src, is_dst=True)
+        if not dst_norm:
+            continue
+
+        ins_rows.append(
+            (
+                row["id"],
+                row["calldate"],
+                src_norm,
+                dst_norm,
+                row["EOT_A"],
+                row["EOT_B"],
+                row["duration"],
+                row["billsec"],
+                row["sentido"],
+                row["disposition"],
+            )
+        )
+
+    if ins_rows:
+        cur.executemany(
+            f"""
+            INSERT INTO {tmp_name}
+                (id, calldate, src, dst, EOT_A, EOT_B,
+                 duration, billsec, sentido, disposition)
+            VALUES
+                (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            """,
+            ins_rows,
+        )
+
+    ok(f"Tabela criada: {tmp_name}")


### PR DESCRIPTION
## Summary
- Drop reduced `src_short`/`dst_short` columns from normalized CDR output
- Recreate normalized CDR table persistently and keep it between runs
- Match DETRAF to CDR using full normalized numbers and retain table for inspection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c06263e248833386cf4374615f4243